### PR TITLE
Add `rehype-truncate` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -69,7 +69,7 @@ See [Creating plugins][create] below.
     — Adds a table of contents (TOC) to the page
 *   [`rehype-truncate`](https://github.com/luk707/rehype-truncate)
     — truncates html to a specified number of characters whilst its preserving
-      structure
+structure
 *   [`rehype-urls`](https://github.com/brechtcs/rehype-urls)
     — rewrite URLs of `href` and `src` attributes
 *   [`rehype-url-inspector`](https://github.com/JS-DevTools/rehype-url-inspector)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -69,7 +69,7 @@ See [Creating plugins][create] below.
     — Adds a table of contents (TOC) to the page
 *   [`rehype-truncate`](https://github.com/luk707/rehype-truncate)
     — truncates html to a specified number of characters whilst its preserving
-structure
+    structure
 *   [`rehype-urls`](https://github.com/brechtcs/rehype-urls)
     — rewrite URLs of `href` and `src` attributes
 *   [`rehype-url-inspector`](https://github.com/JS-DevTools/rehype-url-inspector)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -68,7 +68,7 @@ See [Creating plugins][create] below.
 *   [`rehype-toc`](https://github.com/JS-DevTools/rehype-toc)
     — Adds a table of contents (TOC) to the page
 *   [`rehype-truncate`](https://github.com/luk707/rehype-truncate)
-    - truncates html to a specified number of characters whilst its preserving structure
+    — truncates html to a specified number of characters whilst its preserving structure
 *   [`rehype-urls`](https://github.com/brechtcs/rehype-urls)
     — rewrite URLs of `href` and `src` attributes
 *   [`rehype-url-inspector`](https://github.com/JS-DevTools/rehype-url-inspector)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -67,6 +67,8 @@ See [Creating plugins][create] below.
     — add `id`s to headings
 *   [`rehype-toc`](https://github.com/JS-DevTools/rehype-toc)
     — Adds a table of contents (TOC) to the page
+*   [`rehype-truncate`](https://github.com/luk707/rehype-truncate)
+    - truncates html to a specified number of characters whilst its preserving structure
 *   [`rehype-urls`](https://github.com/brechtcs/rehype-urls)
     — rewrite URLs of `href` and `src` attributes
 *   [`rehype-url-inspector`](https://github.com/JS-DevTools/rehype-url-inspector)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -68,7 +68,8 @@ See [Creating plugins][create] below.
 *   [`rehype-toc`](https://github.com/JS-DevTools/rehype-toc)
     — Adds a table of contents (TOC) to the page
 *   [`rehype-truncate`](https://github.com/luk707/rehype-truncate)
-    — truncates html to a specified number of characters whilst its preserving structure
+    — truncates html to a specified number of characters whilst its preserving
+      structure
 *   [`rehype-urls`](https://github.com/brechtcs/rehype-urls)
     — rewrite URLs of `href` and `src` attributes
 *   [`rehype-url-inspector`](https://github.com/JS-DevTools/rehype-url-inspector)


### PR DESCRIPTION
I recently published a new transformer plugin for rehype which allows you to truncate HTML. I thought this might be of use to others so I've added a reference to it in your plugin documentation.