### PR TITLE
Add `rehype-accessible-emojis` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -21,6 +21,8 @@ topic][topic].
 Have a good idea for a new plugin?
 See [Creating plugins][create] below.
 
+*   [`rehype-accessible-emojis`](https://github.com/GaiAma/Coding4GaiAma/tree/master/packages/rehype-accessible-emojis)
+    — make emojis accessible adding role & aria-label
 *   [`rehype-add-classes`](https://github.com/martypdx/rehype-add-classes)
     — add classes by selector
 *   [`rehype-autolink-headings`](https://github.com/rehypejs/rehype-autolink-headings)


### PR DESCRIPTION
As I couldn't get gatsby-remark-a11y-emoji working with gatsby-plugin-mdx I made this rehype version to make emojis accessible by wrapping them in a <span role="image"> with aria-label set to the emojis description based on gemoji.

<!--
Read the [contributing guidelines](https://github.com/rehypejs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/rehypejs/.github/blob/master/support.md
https://github.com/rehypejs/.github/blob/master/contributing.md
-->
