### PR TITLE
Correct the link URL to "Create a plugin" guide

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -139,7 +139,7 @@ use `unist-util-`, and if it works with virtual files, use `vfile-`.
 
 [spectrum]: https://spectrum.chat/unified/rehype
 
-[guide]: https://unifiedjs.com/create-a-plugin.html
+[guide]: https://unifiedjs.com/learn/guide/create-a-plugin/
 
 [awesome]: https://github.com/rehypejs/awesome-rehype
 


### PR DESCRIPTION
In the "Creating plugins" section, the link to the "Create a plugin" guide is a 404.

This corrects the link URL to `https://unifiedjs.com/learn/guide/create-a-plugin/`

<!--
Read the [contributing guidelines](https://github.com/rehypejs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/rehypejs/.github/blob/master/support.md
https://github.com/rehypejs/.github/blob/master/contributing.md
-->
