### PR TITLE
stringify: fix parse error in types

### DIFF
--- a/packages/rehype-stringify/index.d.ts
+++ b/packages/rehype-stringify/index.d.ts
@@ -4,6 +4,6 @@ import type {Root} from 'hast'
 import type {Plugin} from 'unified'
 // Note: defining all nodes here, such as with `Root | Element | ...` seems
 // to trip TS up.
-const rehypeStringify: Plugin<[Options] | [], Root, string>
+export const rehypeStringify: Plugin<[Options] | [], Root, string>
 export default rehypeStringify
 export type {Options}

--- a/packages/rehype-stringify/index.d.ts
+++ b/packages/rehype-stringify/index.d.ts
@@ -4,6 +4,6 @@ import type {Root} from 'hast'
 import type {Plugin} from 'unified'
 // Note: defining all nodes here, such as with `Root | Element | ...` seems
 // to trip TS up.
-export const rehypeStringify: Plugin<[Options] | [], Root, string>
+declare const rehypeStringify: Plugin<[Options] | [], Root, string>
 export default rehypeStringify
 export type {Options}


### PR DESCRIPTION
On TypeScript 4.3.5 & `remark-stringify` 9.0.0 I get:
> error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier

Adding an `export` seems to make it happy
