### PR TITLE
parse: fix parse error in types

### DIFF
--- a/packages/rehype-parse/index.d.ts
+++ b/packages/rehype-parse/index.d.ts
@@ -2,6 +2,6 @@
 import type {Options, ErrorCode, ErrorSeverity} from './lib/index.js'
 import type {Root} from 'hast'
 import type {Plugin} from 'unified'
-const rehypeParse: Plugin<[Options] | [], string, Root>
+declare const rehypeParse: Plugin<[Options] | [], string, Root>
 export default rehypeParse
 export type {Options, ErrorCode, ErrorSeverity}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

```bash
node_modules/rehype-parse/index.d.ts:5:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

5 const rehypeParse: Plugin<[Options] | [], Root, string>
  ~~~~~
```

Same error existed in rehype-stringify and was fixed by #62 

Applied same fix to index.d.ts in rehype-parse.

<!--do not edit: pr-->
