### PR TITLE
Add `rehype-lodash-template` to list of plugin

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -80,6 +80,8 @@ The list of plugins:
     — resolve line breaks in Chinese paragraphs
 *   [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
     — render math with KaTeX
+*   [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
+    — replace tempalte strings with values from the dictionary
 *   [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)
     — render math with MathJax
 *   [`rehype-meta`](https://github.com/rehypejs/rehype-meta)
@@ -174,8 +176,6 @@ The list of plugins:
     — sort tailwind classes
 *   [`rehype-template`](https://github.com/nzt/rehype-template)
     — wrap content with template literal
-*   [`rehype-template`](https://github.com/viktor-yakubiv/rehype-template)
-    — replace tempalte strings with values from the dictionary
 *   [`rehype-toc`](https://github.com/JS-DevTools/rehype-toc)
     — add a table of contents (TOC) to the page
 *   [`rehype-truncate`](https://github.com/luk707/rehype-truncate)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -174,6 +174,8 @@ The list of plugins:
     — sort tailwind classes
 *   [`rehype-template`](https://github.com/nzt/rehype-template)
     — wrap content with template literal
+*   [`rehype-template`](https://github.com/viktor-yakubiv/rehype-template)
+    — replace tempalte strings with values from the dictionary
 *   [`rehype-toc`](https://github.com/JS-DevTools/rehype-toc)
     — add a table of contents (TOC) to the page
 *   [`rehype-truncate`](https://github.com/luk707/rehype-truncate)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -81,7 +81,7 @@ The list of plugins:
 *   [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
     — render math with KaTeX
 *   [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
-    — replace tempalte strings with values from the dictionary
+    — replace template strings with values from the dictionary
 *   [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)
     — render math with MathJax
 *   [`rehype-meta`](https://github.com/rehypejs/rehype-meta)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] I’ve added docs and tests (to my plugin)

### Description of changes

I created a rehype plugin that utilises the lodash.template function and substitutes values from the dictionary instead of template strings in text and properties in the document. I wrote very basic implementation that is enough for me at the moment and will cover most of the cases but has some limitations (you can find in in the read-me and a test file).

Currently, I would like to publish my package and add it to the list alongside of others. I found that `rehype-template` is already taken. I was also worried that this could be misleading as _template_ is a very generic thing. I would like to discuss with you the best name, publish a package and add it here. My options are `rehype-lodash-template` and `rehype-substitude` but I am open to any name; I will rename the repository, package and the rest accordingly.

I can also transfer the repository to `rehype` organisation if this is welcomed. I assume, doing so I will need to spend much more effort maintaining the project.

<!--do not edit: pr-->
