### PR TITLE
Add `rehype-postcss` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -120,6 +120,8 @@ The list of plugins:
     — partials support for rehype
 *   [`rehype-picture`](https://github.com/rehypejs/rehype-picture)
     — wrap images in `<picture>`s
+*   [`rehype-postcss`](https://github.com/viktor-yakubiv/rehype-postcss)
+    — run PostCSS on `<style>` nodes and elements with a `style` attribute
 *   [`rehype-prevent-favicon-request`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-prevent-favicon-request)
     — prevent a request by setting an empty `favicon.ico`
 *   [`rehype-prism`](https://github.com/mapbox/rehype-prism)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

I wrote a [plugin](https://github.com/viktor-yakubiv/rehype-postcss) that runs PostCSS on `<style>` nodes and `style` attributes in the rehype tree and would like to add it to the list. Thank you in advance 🙂

<!--do not edit: pr--> 
