### PR TITLE
Add `rehype-slug-custom-id` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -170,6 +170,9 @@ The list of plugins:
     — replace slot elements with injected content
 *   [`rehype-slug`](https://github.com/rehypejs/rehype-slug)
     — add `id`s to headings
+*   [`rehype-slug-custom-id`](https://github.com/unicorn-utterances/rehype-slug-custom-id)
+    — add `id`s to headings, with the option to pass a custom ID in the HTML
+    innerText itself
 *   [`rehype-sort-attribute-values`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-sort-attribute-values)
     — sort attribute values
 *   [`rehype-sort-attributes`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-sort-attributes)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -171,8 +171,7 @@ The list of plugins:
 *   [`rehype-slug`](https://github.com/rehypejs/rehype-slug)
     — add `id`s to headings
 *   [`rehype-slug-custom-id`](https://github.com/unicorn-utterances/rehype-slug-custom-id)
-    — add `id`s to headings, with the option to pass a custom ID in the HTML
-    innerText itself
+    — add `id`s to headings, also supports `{#custom-ids}`
 *   [`rehype-sort-attribute-values`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-sort-attribute-values)
     — sort attribute values
 *   [`rehype-sort-attributes`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-sort-attributes)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

As part of a requirement moving from a blog from Gatsby to NextJS (powered by a unist/remark/rehype chain), [I needed a way to create custom IDs from the heading's text](https://github.com/rehypejs/rehype-slug/issues/10). The feature was (entirely understandably) rejected from `rehype-slug`, so I created a custom package with this functionality.


This PR adds said package to the list of `rehype` utilities.
<!--do not edit: pr-->
