### PR TITLE
Add `rehype-jargon` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -74,6 +74,8 @@ The list of plugins:
     — inline and optimize SVG images
 *   [`rehype-ignore`](https://github.com/jaywcjlove/rehype-ignore)
     — ignore content display via HTML comments.
+*   [`rehype-jargon`](https://github.com/freesewing/freesewing/tree/develop/packages/rehype-jargon)
+    — inserts definitions for jargon terms
 *   [`rehype-javascript-to-bottom`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-javascript-to-bottom)
     — move `<script>`s to the end of `<body>`
 *   [`rehype-join-line`](https://github.com/unix/rehype-join-line)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [X] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [X] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [X] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [X] If applicable, I’ve added docs and tests

### Description of changes

Added `rehype-jargon` to the list plugins. Used to be a `remark` plugin but it's not a `rehype` plugin. The other version is no more available.

<!--do not edit: pr-->
