### PR TITLE
rehype-parse: bump parse5 from ^6.0.0 to ^7.0.0

### DIFF
--- a/packages/rehype-parse/lib/index.js
+++ b/packages/rehype-parse/lib/index.js
@@ -27,8 +27,7 @@
  * @typedef {FromParse5Options & ParseFields & ErrorFields} Options
  */
 
-// @ts-expect-error: remove when typed
-import Parser5 from 'parse5/lib/parser/index.js'
+import {Parser as Parser5} from 'parse5'
 import {fromParse5} from 'hast-util-from-parse5'
 import {errors} from './errors.js'
 

--- a/packages/rehype-parse/package.json
+++ b/packages/rehype-parse/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@types/hast": "^2.0.0",
     "hast-util-from-parse5": "^7.0.0",
-    "parse5": "^6.0.0",
+    "parse5": "^7.0.0",
     "unified": "^10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [ ] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [ ] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [ ] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [ ] If applicable, I’ve added docs and tests
* [x] i hate checklists

### Description of changes

update parse5

we already use version 7 in hast-util-from-parse5

https://github.com/syntax-tree/hast-util-from-parse5/blob/fa0be0e589a42b1373d80f290912f6c39bf8731a/package.json#L48


<!--do not edit: pr-->
