### PR TITLE
Add `rehype-extract-meta` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -54,6 +54,8 @@ The list of plugins:
     — add support for serializing HTML in browsers
 *   [`rehype-external-links`](https://github.com/rehypejs/rehype-external-links)
     — add rel (and target) to external links
+*   [`rehype-extract-meta`](https://github.com/gorango/rehype-extract-meta)
+    — extract meta data from an HTML document
 *   [`rehype-figure`](https://github.com/josestg/rehype-figure)
     — support figure and caption from images
 *   [`rehype-format`](https://github.com/rehypejs/rehype-format)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

A `rehype` plugin to extract meta data from an HTML document.

<!--do not edit: pr-->
