### PR TITLE
Add `rehype-sectionize` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -164,7 +164,7 @@ The list of plugins:
     — rewrite element with rehype
 *   [`rehype-sanitize`](https://github.com/rehypejs/rehype-sanitize)
     — sanitize HTML
-*   [`rehype-section`](https://github.com/agentofuser/rehype-section)
+*   [`rehype-sectionize`](https://github.com/hbsnow/rehype-sectionize)
     — wrap headings and their contents into nested `<section>` elements
 *   [`rehype-shift-heading`](https://github.com/rehypejs/rehype-shift-heading)
     — change the rank of headings

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -164,8 +164,10 @@ The list of plugins:
     — rewrite element with rehype
 *   [`rehype-sanitize`](https://github.com/rehypejs/rehype-sanitize)
     — sanitize HTML
-*   [`rehype-sectionize`](https://github.com/hbsnow/rehype-sectionize)
+*   [`rehype-section`](https://github.com/agentofuser/rehype-section)
     — wrap headings and their contents into nested `<section>` elements
+*   [`rehype-sectionize`](https://github.com/hbsnow/rehype-sectionize)
+    — when heading has id, section with id wraps the heading and content
 *   [`rehype-shift-heading`](https://github.com/rehypejs/rehype-shift-heading)
     — change the rank of headings
 *   [`rehype-shiki`](https://github.com/rsclarke/rehype-shiki)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -167,7 +167,8 @@ The list of plugins:
 *   [`rehype-section`](https://github.com/agentofuser/rehype-section)
     — wrap headings and their contents into nested `<section>` elements
 *   [`rehype-sectionize`](https://github.com/hbsnow/rehype-sectionize)
-    — when heading has id, section with id wraps the heading and content
+    — wrap headings and their contents into nested `<section>` elements,
+    with attributes
 *   [`rehype-shift-heading`](https://github.com/rehypejs/rehype-shift-heading)
     — change the rank of headings
 *   [`rehype-shiki`](https://github.com/rsclarke/rehype-shiki)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

The rehype-section was not maintained.
Therefore, this plugin was created to add the id of the heading to the section.

<!--do not edit: pr-->
