### PR TITLE
update parse5 to 7.0.0

### DIFF
--- a/packages/rehype-parse/lib/index.js
+++ b/packages/rehype-parse/lib/index.js
@@ -27,8 +27,7 @@
  * @typedef {FromParse5Options & ParseFields & ErrorFields} Options
  */
 
-// @ts-expect-error: remove when typed
-import Parser5 from 'parse5/lib/parser/index.js'
+import {Parser as Parser5} from 'parse5'
 import {fromParse5} from 'hast-util-from-parse5'
 import {errors} from './errors.js'
 

--- a/packages/rehype-parse/lib/index.js
+++ b/packages/rehype-parse/lib/index.js
@@ -27,7 +27,7 @@
  * @typedef {FromParse5Options & ParseFields & ErrorFields} Options
  */
 
-import {Parser as Parser5} from 'parse5'
+import {parse, parseFragment} from 'parse5'
 import {fromParse5} from 'hast-util-from-parse5'
 import {errors} from './errors.js'
 
@@ -47,21 +47,23 @@ export default function rehypeParse(options) {
 
   /** @type {import('unified').ParserFunction<Root>} */
   function parser(doc, file) {
-    const fn = settings.fragment ? 'parseFragment' : 'parse'
+    const fn = settings.fragment ? parseFragment : parse
     const onParseError = settings.emitParseErrors ? onerror : null
-    const parse5 = new Parser5({
-      sourceCodeLocationInfo: true,
-      onParseError,
-      scriptingEnabled: false
-    })
 
     // @ts-expect-error: `parse5` returns document or fragment, which are always
     // mapped to roots.
-    return fromParse5(parse5[fn](doc), {
-      space: settings.space,
-      file,
-      verbose: settings.verbose
-    })
+    return fromParse5(
+      fn(doc, {
+        sourceCodeLocationInfo: true,
+        onParseError,
+        scriptingEnabled: false
+      }),
+      {
+        space: settings.space,
+        file,
+        verbose: settings.verbose
+      }
+    )
 
     /**
      * @param {{code: string, startLine: number, startCol: number, startOffset: number, endLine: number, endCol: number, endOffset: number}} error

--- a/packages/rehype-parse/package.json
+++ b/packages/rehype-parse/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@types/hast": "^2.0.0",
     "hast-util-from-parse5": "^7.0.0",
-    "parse5": "^6.0.0",
+    "parse5": "^7.0.0",
     "unified": "^10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

I updated `parse5` to `v7.0.0`. This ensures `esm` compatibility for `rehype-parse`.

There was a [prior pull request](https://github.com/rehypejs/rehype/pull/113) that aimed to accomplish this, but it was closed as it needed more work.