### PR TITLE
Add rehype-color-chips to the list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -38,6 +38,8 @@ The list of plugins:
     — add links to headings
 *   [`rehype-citation`](https://github.com/timlrx/rehype-citation)
     — add citation and bibliography from bibtex
+*   [`rehype-color-chips`](https://github.com/shreshthmohan/rehype-color-chips)
+    - add color chips to inline code blocks with color codes
 *   [`rehype-components`](https://github.com/marekweb/rehype-components)
     — render components (custom elements)
 *   [`rehype-concat-css-style`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-concat-css-style)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -39,7 +39,7 @@ The list of plugins:
 *   [`rehype-citation`](https://github.com/timlrx/rehype-citation)
     — add citation and bibliography from bibtex
 *   [`rehype-color-chips`](https://github.com/shreshthmohan/rehype-color-chips)
-    - add color chips to inline code blocks with color codes
+    — add color chips to inline code blocks with color codes
 *   [`rehype-components`](https://github.com/marekweb/rehype-components)
     — render components (custom elements)
 *   [`rehype-concat-css-style`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-concat-css-style)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Added a new rehype plugin to the list at `doc/plugins.md`

<!--do not edit: pr-->
