### PR TITLE
Updated `parse5` to v7

### DIFF
--- a/packages/rehype-parse/package.json
+++ b/packages/rehype-parse/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@types/hast": "^2.0.0",
     "hast-util-from-parse5": "^7.0.0",
-    "parse5": "^6.0.0",
+    "parse5": "^7.0.0",
     "unified": "^10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [X] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [X] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [X] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [X] If applicable, I’ve added docs and tests

### Description of changes

This PR updates the `parse5` dependency of `rehype-parse` from v6 to v7. The main reasoning for this change this is that v6 uses CommonJS modules whereas v7 uses ES Modules, so NodeJS is no longer required.

<!--do not edit: pr-->
