### PR TITLE
Add `rehype-scroll-to-top`, `rehype-smenatic-images` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -169,6 +169,8 @@ The list of plugins:
     — rewrite element with rehype
 *   [`rehype-sanitize`](https://github.com/rehypejs/rehype-sanitize)
     — sanitize HTML
+*   [`rehype-semantic-images`](https://github.com/benjamincharity/rehype-semantic-images)
+    — Enrich HTML images with semantic elements and customizable features
 *   [`rehype-scroll-to-top`](https://github.com/benjamincharity/rehype-scroll-to-top)
     — customizable “Scroll to Top” and “Scroll to Bottom” links
 *   [`rehype-section`](https://github.com/agentofuser/rehype-section)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -169,6 +169,8 @@ The list of plugins:
     — rewrite element with rehype
 *   [`rehype-sanitize`](https://github.com/rehypejs/rehype-sanitize)
     — sanitize HTML
+*   [`rehype-scroll-to-top`](https://github.com/benjamincharity/rehype-scroll-to-top)
+    — add customizable "Scroll to Top" and "Scroll to Bottom" links to HTML documents
 *   [`rehype-section`](https://github.com/agentofuser/rehype-section)
     — wrap headings and their contents into nested `<section>` elements
 *   [`rehype-sectionize`](https://github.com/hbsnow/rehype-sectionize)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -170,7 +170,7 @@ The list of plugins:
 *   [`rehype-sanitize`](https://github.com/rehypejs/rehype-sanitize)
     — sanitize HTML
 *   [`rehype-scroll-to-top`](https://github.com/benjamincharity/rehype-scroll-to-top)
-    — add customizable "Scroll to Top" and "Scroll to Bottom" links to HTML documents
+    — customizable “Scroll to Top” and “Scroll to Bottom” links
 *   [`rehype-section`](https://github.com/agentofuser/rehype-section)
     — wrap headings and their contents into nested `<section>` elements
 *   [`rehype-sectionize`](https://github.com/hbsnow/rehype-sectionize)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -169,8 +169,6 @@ The list of plugins:
     — rewrite element with rehype
 *   [`rehype-sanitize`](https://github.com/rehypejs/rehype-sanitize)
     — sanitize HTML
-*   [`rehype-semantic-images`](https://github.com/benjamincharity/rehype-semantic-images)
-    — Enrich HTML images with semantic elements and customizable features
 *   [`rehype-scroll-to-top`](https://github.com/benjamincharity/rehype-scroll-to-top)
     — customizable “Scroll to Top” and “Scroll to Bottom” links
 *   [`rehype-section`](https://github.com/agentofuser/rehype-section)
@@ -178,6 +176,8 @@ The list of plugins:
 *   [`rehype-sectionize`](https://github.com/hbsnow/rehype-sectionize)
     — wrap headings and their contents into nested `<section>` elements,
     with attributes
+*   [`rehype-semantic-images`](https://github.com/benjamincharity/rehype-semantic-images)
+    — enrich HTML images with semantic elements and customizable features
 *   [`rehype-shift-heading`](https://github.com/rehypejs/rehype-shift-heading)
     — change the rank of headings
 *   [`rehype-shiki`](https://github.com/rsclarke/rehype-shiki)


### PR DESCRIPTION
Add new 'scroll to top' plugin

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Add a new Rehype plugin to the plugins doc. `rehype-scroll-to-top`.

<!--do not edit: pr-->
