### PR TITLE
Add `rehype-highlight-code-lines` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -68,6 +68,8 @@ The list of plugins:
   — syntax highlight code blocks with Highlight.js via `lowlight`
 * [`rehype-highlight-code-block`](https://github.com/mapbox/rehype-highlight-code-block)
   — syntax highlight code blocks with any function you provide
+* [`rehype-highlight-code-lines`](https://github.com/ipikuka/rehype-highlight-code-lines)
+  — add line numbers to code blocks; allow highlighting of desired code lines
 * [`rehype-infer-description-meta`](https://github.com/rehypejs/rehype-infer-description-meta)
   — infer file metadata from the contents of the document
 * [`rehype-infer-reading-time-meta`](https://github.com/rehypejs/rehype-infer-reading-time-meta)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Added a new plugin **`rehype-highlight-code-lines`** to list of plugins

https://github.com/ipikuka/rehype-highlight-code-lines
https://www.npmjs.com/package/rehype-highlight-code-lines

It is `rehype plugin` to add container to each code line in a code block, allowing numbering of the code block and highlighting desired lines of code.

The `rehype-highlight-code-lines` works with `rehype-highlight` well; and should be used after `rehype-highlight` in the plugin chain. The `rehype-highlight-code-lines` also works with other code highlighters that have no line numbering and line highlighting features.

**A snapshot from a working app:**
![markdown code block input](https://github.com/rehypejs/rehype-highlight/assets/30029208/d597f4e5-d7ca-4a84-b843-950094e4a49b)
![markdown code block result](https://github.com/rehypejs/rehype-highlight/assets/30029208/908449d6-8028-4ecd-8536-3e747c725da7)

<!--do not edit: pr-->
