### PR TITLE
[add] add rehype-katex-notranslate plugin for docs

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -8,10 +8,12 @@ This page lists existing plugins.
 
 ## Contents
 
-* [List of plugins](#list-of-plugins)
-* [List of utilities](#list-of-utilities)
-* [Use plugins](#use-plugins)
-* [Create plugins](#create-plugins)
+- [Plugins](#plugins)
+  - [Contents](#contents)
+  - [List of plugins](#list-of-plugins)
+  - [List of utilities](#list-of-utilities)
+  - [Use plugins](#use-plugins)
+  - [Create plugins](#create-plugins)
 
 ## List of plugins
 
@@ -92,6 +94,8 @@ The list of plugins:
   — resolve line breaks in Chinese paragraphs
 * [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
   — render math with KaTeX
+* [`rehype-katex-notranslate`](https://github.com/PrinOrange/rehype-katex-notranslate)
+  — Add the attribute translate="no" to the katex blocks to prevent the them from being translated by webpage translation tools.
 * [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
   — replace template strings with values from the dictionary
 * [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -95,7 +95,7 @@ The list of plugins:
 * [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
   — render math with KaTeX
 * [`rehype-katex-notranslate`](https://github.com/PrinOrange/rehype-katex-notranslate)
-  — Add the attribute translate="no" to the katex blocks to prevent the them from being translated by webpage translation tools.
+  — Add `translate="no"` to KaTeX blocks to prevent translation.
 * [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
   — replace template strings with values from the dictionary
 * [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -93,7 +93,7 @@ The list of plugins:
 * [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
   — render math with KaTeX
 * [`rehype-katex-notranslate`](https://github.com/PrinOrange/rehype-katex-notranslate)
-  — Add `translate="no"` to KaTeX blocks to prevent translation.
+  — add `translate="no"` to KaTeX blocks to prevent translation
 * [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
   — replace template strings with values from the dictionary
 * [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -8,12 +8,10 @@ This page lists existing plugins.
 
 ## Contents
 
-- [Plugins](#plugins)
-  - [Contents](#contents)
-  - [List of plugins](#list-of-plugins)
-  - [List of utilities](#list-of-utilities)
-  - [Use plugins](#use-plugins)
-  - [Create plugins](#create-plugins)
+* [List of plugins](#list-of-plugins)
+* [List of utilities](#list-of-utilities)
+* [Use plugins](#use-plugins)
+* [Create plugins](#create-plugins)
 
 ## List of plugins
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

When a page contains a large number of katex formulas, if we want to use a tool to translate the webpage (such as the built-in translation tool of Google Chrome), the translation tool will often translate the symbols in the katex block, which will cause the formula to be destroyed.

So I wrote a rehype plugin [rehype-katex-notranslate](https://www.npmjs.com/package/rehype-katex-notranslate). This plugin add the attribute translate="no" to the katex formula generated by rehype-katex to prevent the formulas from being recognized and translated by webpage and browser translation tools.

<!--do not edit: pr-->
