### PR TITLE
Add `rehype-mathml` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -98,6 +98,8 @@ The list of plugins:
   — replace template strings with values from the dictionary
 * [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)
   — render math with MathJax
+* [`rehype-mathml`](https://github.com/Daiji256/rehype-mathml)
+  — render math with MathML
 * [`rehype-mermaidjs`](https://github.com/remcohaszing/rehype-mermaidjs)
   — render mermaid diagrams
 * [`rehype-meta`](https://github.com/rehypejs/rehype-meta)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

Add [`rehype-mathml`](https://github.com/Daiji256/rehype-mathml) to list of plugins

Rendering math with MathML is lightweight and supported by many browsers.
I wanted a plugin for rendering math with MathML, similar to `rehype-mathjax` and `rehype-katex`, so I have created `rehype-mathml`.

npm: [`@daiji256/rehype-mathml`](https://www.npmjs.com/package/@daiji256/rehype-mathml)

<!--do not edit: pr-->
