### PR TITLE
Add `rehype-wrap-sibling` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -238,6 +238,8 @@ The list of plugins:
   — wrap selected elements with a given element
 * [`rehype-wrap-all`](https://github.com/florentb/rehype-wrap-all)
   — wrap all matching elements with a given element
+* [`rehype-wrap-sibling`](https://github.com/jamesgeorgewilliams/rehype-wrap-sibling)
+  — wrap a selected element(s) and its sibling in a container element
 
 ## List of utilities
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Arehypejs&type=issues and https://github.com/orgs/rehypejs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

The `rehype-wrap-sibling` plugin wraps a selected element(s) and its sibling in a container element. This plugin would address the topic of this [discussion](https://github.com/orgs/remarkjs/discussions/753) in `remarkjs`.  It can also be useful for wrapping sibling elements in order to make CSS layouts less cumbersome. 

<!--do not edit: pr-->
