### PR TITLE
Add `rehype-graphviz-diagram`

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -8,10 +8,12 @@ This page lists existing plugins.
 
 ## Contents
 
-* [List of plugins](#list-of-plugins)
-* [List of utilities](#list-of-utilities)
-* [Use plugins](#use-plugins)
-* [Create plugins](#create-plugins)
+- [Plugins](#plugins)
+  - [Contents](#contents)
+  - [List of plugins](#list-of-plugins)
+  - [List of utilities](#list-of-utilities)
+  - [Use plugins](#use-plugins)
+  - [Create plugins](#create-plugins)
 
 ## List of plugins
 
@@ -92,6 +94,8 @@ The list of plugins:
   — resolve line breaks in Chinese paragraphs
 * [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
   — render math with KaTeX
+* [`rehype-katex-notranslate`](https://github.com/PrinOrange/rehype-katex-notranslate)
+  — Add the attribute translate="no" to the katex blocks to prevent the them from being translated by webpage translation tools.
 * [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
   — replace template strings with values from the dictionary
 * [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -95,7 +95,7 @@ The list of plugins:
 * [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
   — render math with KaTeX
 * [`rehype-katex-notranslate`](https://github.com/PrinOrange/rehype-katex-notranslate)
-  — Add the attribute translate="no" to the katex blocks to prevent the them from being translated by webpage translation tools.
+  — Add `translate="no"` to KaTeX blocks to prevent translation.
 * [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
   — replace template strings with values from the dictionary
 * [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -93,7 +93,7 @@ The list of plugins:
 * [`rehype-katex`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex)
   — render math with KaTeX
 * [`rehype-katex-notranslate`](https://github.com/PrinOrange/rehype-katex-notranslate)
-  — Add `translate="no"` to KaTeX blocks to prevent translation.
+  — add `translate="no"` to KaTeX blocks to prevent translation
 * [`rehype-lodash-template`](https://github.com/viktor-yakubiv/rehype-lodash-template)
   — replace template strings with values from the dictionary
 * [`rehype-mathjax`](https://github.com/remarkjs/remark-math/tree/main/packages/rehype-mathjax)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -8,12 +8,10 @@ This page lists existing plugins.
 
 ## Contents
 
-- [Plugins](#plugins)
-  - [Contents](#contents)
-  - [List of plugins](#list-of-plugins)
-  - [List of utilities](#list-of-utilities)
-  - [Use plugins](#use-plugins)
-  - [Create plugins](#create-plugins)
+* [List of plugins](#list-of-plugins)
+* [List of utilities](#list-of-utilities)
+* [Use plugins](#use-plugins)
+* [Create plugins](#create-plugins)
 
 ## List of plugins
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -69,7 +69,7 @@ The list of plugins:
 * [`rehype-format`](https://github.com/rehypejs/rehype-format)
   — format HTML
 * [`rehype-graphviz-diagram`](https://github.com/PrinOrange/rehype-graphviz-diagram)
-  — allows you transform graphviz codes into SVG diagrams for HTML document
+  — render Graphviz diagrams as SVG
 * [`rehype-highlight`](https://github.com/rehypejs/rehype-highlight)
   — syntax highlight code blocks with Highlight.js via `lowlight`
 * [`rehype-highlight-code-block`](https://github.com/mapbox/rehype-highlight-code-block)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -68,6 +68,8 @@ The list of plugins:
   — support figure and caption from images
 * [`rehype-format`](https://github.com/rehypejs/rehype-format)
   — format HTML
+* [`rehype-graphviz-diagram`](https://github.com/PrinOrange/rehype-graphviz-diagram)
+  — allows you transform graphviz codes into SVG diagrams for HTML document
 * [`rehype-highlight`](https://github.com/rehypejs/rehype-highlight)
   — syntax highlight code blocks with Highlight.js via `lowlight`
 * [`rehype-highlight-code-block`](https://github.com/mapbox/rehype-highlight-code-block)


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Arehypejs&type=issues and https://github.com/orgs/rehypejs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add `rehype-graphviz-diagram` to plugin list. The `rehype-graphviz-diagram` is the wrapper for [graphviz](https://graphviz.org/) used for integrating with unified.

It allows your insert diagrams in markdown or html content. 

Here is the [README file](https://github.com/PrinOrange/rehype-graphviz-diagram). And plugin effect,

![image](https://github.com/user-attachments/assets/caffdd46-ca41-4c05-89bc-56551595ae33)

<!--do not edit: pr-->
