### PR TITLE
Add `rehype-mdx-toc` to export toc into MDX module

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -104,12 +104,12 @@ The list of plugins:
   — render math with MathJax
 * [`rehype-mathml`](https://github.com/Daiji256/rehype-mathml)
   — render math as MathML with [Temml](https://temml.org/)
+* [`rehype-mdx-toc`](https://github.com/boning-w/rehype-mdx-toc)
+  — export the table of contents data into MDX module
 * [`rehype-mermaidjs`](https://github.com/remcohaszing/rehype-mermaidjs)
   — render mermaid diagrams
 * [`rehype-meta`](https://github.com/rehypejs/rehype-meta)
   — add metadata to the head of a document
-* [`rehype-mdx-toc`](https://github.com/boning-w/rehype-mdx-toc)
-  — export the table of contents data into MDX module
 * [`rehype-minify`](https://github.com/rehypejs/rehype-minify)
   — minify HTML
 * [`rehype-minify-attribute-whitespace`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-minify-attribute-whitespace)

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -108,6 +108,8 @@ The list of plugins:
   — render mermaid diagrams
 * [`rehype-meta`](https://github.com/rehypejs/rehype-meta)
   — add metadata to the head of a document
+* [`rehype-mdx-toc`](https://github.com/boning-w/rehype-mdx-toc)
+  — export the table of contents data into MDX module
 * [`rehype-minify`](https://github.com/rehypejs/rehype-minify)
   — minify HTML
 * [`rehype-minify-attribute-whitespace`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-minify-attribute-whitespace)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Arehypejs&type=issues and https://github.com/orgs/rehypejs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

I wrote a rehype plugin [rehype-mdx-toc](https://github.com/boning-w/rehype-mdx-toc) that allows users to export the table of contents (TOC) data as a named export from an MDX module.

#### Why another table of contents plugin?

Since MDX supports exporting data from MDX modules, it's much more convinent to export the TOC — so that users can use it whatever they like, just like with [remark-mdx-frontmatter](https://github.com/remcohaszing/remark-mdx-frontmatter/tree/main).

Simple usage:

```js
import { compile, run } from "@mdx-js/mdx";
import rehypeMdxToc from "rehype-mdx-toc";
import * as runtime from "react/jsx-runtime";

const mdxContent = `
# Heading 1
## Heading 2
### Heading 3
`;

const compiled = await compile(mdxContent, {
  outputFormat: "function-body",
  rehypePlugins: [rehypeMdxToc],
});
const result = await run(compiled, { ...runtime });
const toc = result.toc;
console.log(toc);
```

With some bundlers — like [@mdx-js/esbuild](https://mdxjs.com/packages/esbuild/), [@mdx-js/rollup](https://mdxjs.com/packages/rollup/), and [@mdx-js/loader](https://mdxjs.com/packages/loader/), we can easily import the TOC data at build time:

```js
import MDXContent, { toc } from "./you-mdx-file.mdx";
```

<!--do not edit: pr-->
