### PR TITLE
Add `rehype-code-meta` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -43,7 +43,9 @@ The list of plugins:
 * [`rehype-class-names`](https://github.com/riderjensen/rehype-class-names)
   — add classes by selector
 * [`rehype-code-group`](https://github.com/ITZSHOAIB/rehype-code-group)
-  — group code blocks (or any element) with highly customizable tabs.
+  — group code blocks (or any element) with highly customizable tabs
+* [`rehype-code-meta`](https://github.com/ipikuka/rehype-code-meta)
+  — copy `code.data.meta` to `code.properties.metastring`
 * [`rehype-color-chips`](https://github.com/shreshthmohan/rehype-color-chips)
   — add color chips to inline code blocks with color codes
 * [`rehype-components`](https://github.com/marekweb/rehype-components)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Arehypejs&type=issues and https://github.com/orgs/rehypejs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

[**`rehype-code-meta`**](https://github.com/ipikuka/rehype-code-meta) is useful when you use **`rehype-raw`** (**`hast-util-raw`**) since it destroys `code.data.meta`. 

**`rehype-code-meta`** copies `code.data.meta` to `code.properties.metastring` to preserve tha data before **`rehype-raw`**.

This change adds **`rehype-code-meta`** into plugin list.

<!--do not edit: pr-->
