### PR TITLE
Add `rehype-pre-language` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -148,6 +148,8 @@ The list of plugins:
   — wrap images in `<picture>`s
 * [`rehype-postcss`](https://github.com/viktor-yakubiv/rehype-postcss)
   — run PostCSS on `<style>` nodes and elements with a `style` attribute
+* [`rehype-pre-language`](https://github.com/ipikuka/rehype-pre-language)
+  — add language information into `<pre>` element as a property
 * [`rehype-prevent-favicon-request`](https://github.com/rehypejs/rehype-minify/tree/main/packages/rehype-prevent-favicon-request)
   — prevent a request by setting an empty `favicon.ico`
 * [`rehype-prism`](https://github.com/mapbox/rehype-prism)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Arehypejs&type=issues and https://github.com/orgs/rehypejs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

[**`rehype-pre-language`**](https://github.com/ipikuka/rehype-pre-language) is useful if there is no language information in `<pre>` element but `<code>` element like `<pre><code className="language-typescript"></pre>`, and you need `<pre>` element to have language information. 

This change adds **`rehype-pre-language`** into plugin list.

<!--do not edit: pr-->

